### PR TITLE
Add a compiler

### DIFF
--- a/htm/__init__.py
+++ b/htm/__init__.py
@@ -257,6 +257,8 @@ def htm(func=None, *, cache_maxsize=128):
         def __htm(strings, values):
             ops = cached_parse(strings)
             return htm_eval(h, ops, values)
+
+        __htm._eval = functools.partial(htm_eval, h)
         return __htm
 
     if func is not None:

--- a/htm/compile.py
+++ b/htm/compile.py
@@ -1,0 +1,46 @@
+import ast
+import astor
+import functools
+from tagged import split
+from htm import htm_parse
+
+
+class Rewrite(ast.NodeTransformer):
+    def visit_Call(self, node):
+        self.generic_visit(node)
+
+        if node.func.__class__.__name__ != "Name" or node.func.id != "html":
+            return node
+        if len(node.args) != 1 or node.args[0].__class__.__name__ != "Str":
+            return node
+
+        strings, exprs = split(node.args[0].s)
+        ops = htm_parse(strings)
+
+        func_node = ast.Attribute(value=node.func, attr="_eval", ctx=ast.Load())
+        ops_node = to_ast(ops)
+        exprs_node = ast.List(elts=[ast.parse(expr, mode="eval") for expr in exprs], ctx=ast.Load())
+
+        new_node = ast.Call(func=func_node, args=[ops_node, exprs_node], keywords=[])
+        return ast.copy_location(new_node, node)
+
+
+@functools.singledispatch
+def to_ast(value):
+    raise TypeError("unknown type")
+to_ast.register(str, lambda s: ast.Str(s=s))
+to_ast.register(int, lambda n: ast.Num(n=n))
+to_ast.register(bool, lambda b: ast.NameConstant(b))
+to_ast.register(tuple, lambda t: ast.Tuple(elts=[to_ast(e) for e in t], ctx=ast.Load()))
+to_ast.register(list, lambda l: ast.Tuple(elts=[to_ast(e) for e in l], ctx=ast.Load()))
+
+
+def compile(source):
+    root = ast.parse(source)
+    root = Rewrite().visit(root)
+    return astor.to_source(root)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.stdout.write(compile(sys.stdin.read()))

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,10 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/jviide/htm.py",
     packages=setuptools.find_packages(),
-    install_requires=["tagged"],
+    install_requires=["tagged>=0.0.2"],
+    extras_require = {
+        "compile": ["astor>=0.8.0"]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This pull request adds a new (runnable) module, `htm.compile`, that can be used to partially precompile the tagged htm templates.

The code generation part depends on the fabulous [astor](https://pypi.org/project/astor/) package, and the feature has to be enabled on install. You can try this by running the following command on the repository root:

```
$ pip3 install .[compile]
```

After this the compiler can be used:

```
$ python3 -m htm.compile < somefile.py
```

Let's assume `somefile.py` contains the following piece of code:

```py
from htm import htm

@htm
def html(tag, props, children):
    return tag, props, children

html("""
  <div foo={1+2} />
""")
```

The output after compilation would be something like this:

```py
from htm import htm


@htm
def html(tag, props, children):
    return tag, props, children


html._eval((('OPEN', False, 'div'), ('PROP_SINGLE', 'foo', True, 0), (
    'CLOSE',)), [(1 + 2)])
```