### PR TITLE
[Draft] Add an HTM transpiler via Pyalect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# VSCode
+.vscode
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/htm/dialect.py
+++ b/htm/dialect.py
@@ -1,0 +1,84 @@
+import ast
+import sys
+
+import tagged
+import pyalect
+
+from htm import htm_parse
+
+if sys.version_info < (3, 6):
+    raise RuntimeError("The HTM dialect requires Python>=3.6")
+
+
+class Transpiler(pyalect.Transpiler):
+    def __init__(self, dialect):
+        self.dialect = dialect
+
+    def transform_ast(self, node):
+        return NodeTransformer().visit(node)
+
+
+class NodeTransformer(ast.NodeTransformer):
+    def visit_Call(self, node):
+        if isinstance(node.func, ast.Name):
+            if node.func.id == "html":
+                if (
+                    node.keywords
+                    or len(node.args) != 1
+                    or not isinstance(node.args[0], ast.Str)
+                ):
+                    raise RuntimeError(
+                        "html expects a string as its sole positional argument"
+                    )
+                else:
+                    htm_string = node.args[0].s
+                expr = make_htm_expr(htm_string)
+                new_call_node = ast.parse(expr).body[0].value
+                return ast.copy_location(new_call_node, node)
+        return node
+
+
+def make_htm_expr(text):
+    src = ""
+    is_first_child = True
+    strings, exprs = tagged.split(text)
+    for op_type, *data in htm_parse(strings):
+        if op_type == "OPEN":
+            is_first_child = True
+            src += "html("
+            value, tag = data
+            src += (exprs[tag] if value else repr(tag)) + ", {"
+        elif op_type == "CLOSE":
+            if is_first_child:
+                src += "}, ["
+            src += "])"
+        elif op_type == "SPREAD":
+            value, item = data
+            src += "**" + (exprs[item] if value else item) + ", "
+        elif op_type == "PROP_SINGLE":
+            attr, value, item = data
+            src += repr(attr) + ": (" + (exprs[item] if value else repr(item)) + "), "
+        elif op_type == "PROP_MULTI":
+            attr, items = data
+            src += (
+                repr(attr)
+                + ": ("
+                + "+".join(
+                    repr(value) if is_text else "str(%s)" % exprs[value]
+                    for (is_text, value) in items
+                )
+                + "), "
+            )
+        elif op_type == "CHILD":
+            if is_first_child:
+                is_first_child = False
+                src += "}, ["
+            value, item = data
+            src += values[item] if value else repr(item) + ","
+        else:
+            raise BaseException("unknown op")
+    return src
+
+
+if "html" not in pyalect.registered():
+    pyalect.register("html", Transpiler)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
     url="https://github.com/jviide/htm.py",
     packages=setuptools.find_packages(),
     install_requires=["tagged"],
+    extras_require={"dialect": ["pyalect"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The following is accomplished with [Pyalect](https://github.com/rmorshea/pyalect)...

In IPython or Jupyter you will now be able to use a `dialect` magic to write HTM after `htm.dialect` has been imported.

```python
>>> import htm.dialect
>>> %%dialect html
...
... def html(tag, props, children):
...     return tag, props, children
...
... a = 1
... b = {"bar": 100}
... c = "span"
... d = "world"
...
... html("""
...     <div foo={a+2} ...{b}>
...     <{c}>Hello, {d}!<//>
... </div>
... """)
('div', {'foo': 3, 'bar': 100}, [('span', {}, ['Hello,', 'world', '!'])])
```

The same can be achieved in normal Python modules by adding a `# dialect=html` header comment and importing `htm.dialect` at the application entrypoint:

```python
import htm.dialect
# all following imports with an HTML dialect header will be transpiled
import my_htm_app
```

> in `my_htm_app`

```python
# dialect=html

def html(tag, props, children):
    return tag, props, children

# your HTM code here...
```